### PR TITLE
Integration sets

### DIFF
--- a/tests/adaptivity/test_adding.py
+++ b/tests/adaptivity/test_adding.py
@@ -43,17 +43,15 @@ def test_adding():
         for idx in range(3):
             integral_output = integrator.integrate(t=t)
             assert (integral_output.integral - correct)/correct < atol
-            t_pruned = integral_output.t_pruned
+            t_optimal = integral_output.t_optimal
             if idx < 1:
-                error_message = f"For {type} integrator method {method}: length of t {t.shape} shoud be < to t_pruned {t_pruned.shape}"
-                assert len(t) < len(integral_output.t_pruned), error_message
+                error_message = f"For {type} integrator method {method}: length of t {t.shape} shoud be < to t_optimal {t_optimal.shape}"
+                assert len(t) < len(integral_output.t_optimal), error_message
             else:
-                error_message = f"For {type} integrator method {method}: length of t {t.shape} shoud be <= to t_pruned {t_pruned.shape}"
-                assert len(t) <= len(integral_output.t_pruned), error_message
+                error_message = f"For {type} integrator method {method}: length of t {t.shape} shoud be <= to t_optimal {t_optimal.shape}"
+                assert len(t) <= len(integral_output.t_optimal), error_message
             t_flat = torch.flatten(integral_output.t, start_dim=0, end_dim=1)
-            t_pruned_flat = torch.flatten(t_pruned, start_dim=0, end_dim=1)
+            t_optimal_flat = torch.flatten(t_optimal, start_dim=0, end_dim=1)
             assert torch.all(t_flat[1:] - t_flat[:-1] >= 0)
-            assert torch.all(t_pruned_flat[1:] - t_pruned_flat[:-1] >= 0)
             assert np.allclose(integral_output.t[:-1,-1,:], integral_output.t[1:,0,:])
-            assert np.allclose(t_pruned[:-1,-1,:], t_pruned[1:,0,:])
-            t = t_pruned
+            t = t_optimal

--- a/tests/adaptivity/test_removal.py
+++ b/tests/adaptivity/test_removal.py
@@ -20,17 +20,15 @@ def test_removal():
         t = dense_t
         for idx in range(3):
             integral_output = integrator.integrate(t=t)
-            t_pruned = integral_output.t_pruned
+            t_optimal = integral_output.t_optimal
             if idx < 1:
-                error_message = f"For {type} integrator: length of t {t.shape} shoud be > to t_pruned {t_pruned.shape}"
-                assert len(t) > len(t_pruned), error_message
+                error_message = f"For {type} integrator: length of t {t.shape} shoud be > to t_optimal {t_optimal.shape}"
+                assert len(t) > len(t_optimal), error_message
             else:
-                error_message = f"For {type} integrator: length of t {t.shape} shoud be >= to t_pruned {t_pruned.shape}"
-                assert len(t) >= len(t_pruned), error_message
+                error_message = f"For {type} integrator: length of t {t.shape} shoud be >= to t_optimal {t_optimal.shape}"
+                assert len(t) >= len(t_optimal), error_message
             t_flat = torch.flatten(integral_output.t, start_dim=0, end_dim=1)
-            t_pruned_flat = torch.flatten(t_pruned, start_dim=0, end_dim=1)
+            t_optimal_flat = torch.flatten(t_optimal, start_dim=0, end_dim=1)
             assert torch.all(t_flat[1:] - t_flat[:-1] >= 0)
-            assert torch.all(t_pruned_flat[1:] - t_pruned_flat[:-1] >= 0)
             assert np.allclose(integral_output.t[:-1,-1,:], integral_output.t[1:,0,:])
-            assert np.allclose(t_pruned[:-1,-1,:], t_pruned[1:,0,:])
-            t = t_pruned
+            t = t_optimal

--- a/tests/integrals/test_integrals.py
+++ b/tests/integrals/test_integrals.py
@@ -39,8 +39,6 @@ def test_integrals():
                 error_string = f"{sampling_name} {method} failed to properly integrate {name}, calculated {integral_output.integral.item()} but expected {correct.item()}"
                 t_flat = torch.flatten(integral_output.t[:,:,0])
                 t_flat_unique = torch.flatten(integral_output.t[:,1:,0])
-                print("VALS", integral_output.integral, correct, integral_output.t.shape, torch.sum(t_flat[1:] - t_flat[:-1] + 1e-15 < 0), torch.sum(t_flat_unique[1:] - t_flat_unique[:-1] + 1e-15 < 0))
-                print("CUTOFF", cutoff, torch.abs((integral_output.integral - correct)/correct))
                 """
                 serial_integral = ode_path_integral(
                     ode_fxn=ode,
@@ -60,7 +58,6 @@ def test_integrals():
                 assert torch.all(t_flat[1:] - t_flat[0:-1] >= 0)
                 assert torch.all(t_optimal_flat[1:] - t_optimal_flat[0:-1] >= 0)
                 assert torch.allclose(integral_output.t[1:,0,:], integral_output.t[:-1,-1,:])
-                #assert torch.allclose(integral_output.t_optimal[1:,0,:], integral_output.t_optimal[:-1,-1,:])
                 
                 """
                 if max_batch is None:
@@ -76,5 +73,3 @@ def test_integrals():
                     assert len(no_batch_integral.t_optimal) <= len(integral_output.t_optimal) 
                 """
         break
-
-test_integrals()

--- a/tests/integrals/test_integrals.py
+++ b/tests/integrals/test_integrals.py
@@ -26,6 +26,7 @@ def test_integrals():
             #if method != 'fehlberg2':
             #    continue
             for name, (ode, solution, cutoff) in ODE_dict.items():
+                print("INTEGRAL", method, name, sampling_name)
                 correct = solution(t_init=t_init, t_final=t_final)
                 parallel_integrator = get_parallel_RK_solver(
                     sampling_type, method=method, atol=atol, rtol=rtol, remove_cut=0.1
@@ -55,11 +56,11 @@ def test_integrals():
                 assert torch.abs((integral_output.integral - correct)/correct) < cutoff, error_string
 
                 t_flat = torch.flatten(integral_output.t, start_dim=0, end_dim=1)
-                t_pruned_flat = torch.flatten(integral_output.t_pruned, start_dim=0, end_dim=1)
+                t_optimal_flat = torch.flatten(integral_output.t_optimal, start_dim=0, end_dim=1)
                 assert torch.all(t_flat[1:] - t_flat[0:-1] >= 0)
-                assert torch.all(t_pruned_flat[1:] - t_pruned_flat[0:-1] >= 0)
+                assert torch.all(t_optimal_flat[1:] - t_optimal_flat[0:-1] >= 0)
                 assert torch.allclose(integral_output.t[1:,0,:], integral_output.t[:-1,-1,:])
-                assert torch.allclose(integral_output.t_pruned[1:,0,:], integral_output.t_pruned[:-1,-1,:])
+                #assert torch.allclose(integral_output.t_optimal[1:,0,:], integral_output.t_optimal[:-1,-1,:])
                 
                 """
                 if max_batch is None:
@@ -72,7 +73,7 @@ def test_integrals():
                         assert torch.abs(1 - (no_batch_integral.integral/integral_output.integral)) < rel_tol
                         assert 10*torch.abs(no_batch_integral.integral_error) >= torch.abs(integral_output.integral_error)
                     assert len(no_batch_integral.t) <= len(integral_output.t)
-                    assert len(no_batch_integral.t_pruned) <= len(integral_output.t_pruned) 
+                    assert len(no_batch_integral.t_optimal) <= len(integral_output.t_optimal) 
                 """
         break
 

--- a/tests/ode_path_integral_fxn/test_integral.py
+++ b/tests/ode_path_integral_fxn/test_integral.py
@@ -35,7 +35,7 @@ def test_ode_path_integral_fxn():
 
         assert_allclose(OPI_integral.integral, RK_integral.integral)
         assert_allclose(OPI_integral.integral_error, RK_integral.integral_error)
-        assert_allclose(OPI_integral.t_pruned, RK_integral.t_pruned)
+        assert_allclose(OPI_integral.t_optimal, RK_integral.t_optimal)
         assert_allclose(OPI_integral.y, RK_integral.y)
         assert_allclose(OPI_integral.t, RK_integral.t)
         assert_allclose(OPI_integral.h, RK_integral.h)
@@ -69,7 +69,7 @@ def test_ode_path_integral_fxn():
 
         assert_allclose(OPI_integral.integral, RK_integral.integral)
         assert_allclose(OPI_integral.integral_error, RK_integral.integral_error)
-        assert_allclose(OPI_integral.t_pruned, RK_integral.t_pruned)
+        assert_allclose(OPI_integral.t_optimal, RK_integral.t_optimal)
         assert_allclose(OPI_integral.y, RK_integral.y)
         assert_allclose(OPI_integral.t, RK_integral.t)
         assert_allclose(OPI_integral.h, RK_integral.h)

--- a/torchpathdiffeq/base.py
+++ b/torchpathdiffeq/base.py
@@ -130,7 +130,7 @@ class SolverBase(DistributedEnvironment):
         raise NotImplementedError
     
     def _integral_loss(self, integral, *args, **kwargs):
-        return integral
+        return integral.integral
     
     def integrate(
             self,

--- a/torchpathdiffeq/base.py
+++ b/torchpathdiffeq/base.py
@@ -27,7 +27,7 @@ class IntegralOutput():
     integral: torch.Tensor
     loss: torch.Tensor = None
     gradient_taken: bool = None
-    t_pruned: torch.Tensor = None
+    t_optimal: torch.Tensor = None
     t: torch.Tensor = None
     h: torch.Tensor = None
     y: torch.Tensor = None


### PR DESCRIPTION
Evaluates integration steps based on a saved array of the integration step barriers. Whenever an additional step is needed the start value of that step is added to the array. To evaluate steps the integrator takes the maximum steps that can fit in memory. Within this loop the gradient is taken on steps that pass the error requirements and these evaluations are then deleted. This process avoids linking between tensors and subsequent issues with garbage collection.